### PR TITLE
fix[Docs][API][Whole-System-Warranty] : Make sbSalesLeadId required as source of truth

### DIFF
--- a/api-reference/endpoint/order/create-contract-whole-system-warranty.mdx
+++ b/api-reference/endpoint/order/create-contract-whole-system-warranty.mdx
@@ -12,25 +12,22 @@ openapi: 'POST /partner/api/v1/order/whole-system'
 
 ## Overview
 
-This endpoint creates warranty contract for a whole system order. It is used after obtaining warranty quotes from the **List Quotes for Whole System Warranty** endpoint.
+This endpoint creates or updates a warranty contract for a whole system order. It is used after obtaining warranty quotes from the **List Quotes for Whole System Warranty** endpoint.
 
 ### Flow
 
 1. First, call the **List Quotes for Whole System Warranty** endpoint to get available warranty quotes for your system order
 2. Select the desired warranty plan from the returned `warrantyQuoteItemList`
-3. Submit the selected warranty details along with the line items to this endpoint to create the contract
+3. Submit the selected warranty details and customer information to this endpoint. Line items, total covered amount, and warranty duration are read from the sales lead identified by `sbSalesLeadId` — they do not need to be sent in the request.
 
 ### Request Details
 
+- **`sbSalesLeadId`** - The sales lead Id obtained from the List Quotes API response. The contract's covered line items, purchase price, and warranty duration are derived from this lead.
 - **`warrantyQuoteId`** - The unique quote Id received from the quote endpoint
 - **`warrantyQuoteItemId`** - The unique identifier for the warranty quote item obtained from the quote endpoint
-- **`lineItemList`** - The complete list of products with their coverage status (`isCovered: true/false`)
 
 <Note>
-Either `sbSalesLeadId` or `lineItemList` is required in the request:
-
-- **`sbSalesLeadId`** - Use this if you have already obtained quotes and have the sales lead Id from the List Quotes API response
-- **`lineItemList`** - Use this to provide the complete list of products with their coverage status when creating a new contract
+`sbSalesLeadId` is required and is the source of truth for line items. Generate the lead first via the **List Quotes for Whole System Warranty** endpoint; do not send a `lineItemList` — any value is ignored.
 </Note>
 
 <Note>

--- a/api-reference/endpoint/order/create-contract-whole-system-warranty.mdx
+++ b/api-reference/endpoint/order/create-contract-whole-system-warranty.mdx
@@ -39,6 +39,21 @@ If a contract already exists for the provided `sbSalesLeadId`, calling this endp
 - **Customer details** and other non-line item fields can be updated at any time
 </Note>
 
+### Validations
+
+The endpoint performs the following cross-checks before creating or updating a contract. Each failed check returns the listed error code and short-circuits the request before any side effect.
+
+| Check | Error |
+|-------|-------|
+| `sbSalesLeadId` exists **and** belongs to the requesting `storeId` (lookup is keyed by both) | `515` Sales Lead Not Found |
+| `warrantyQuoteId` matches the `sbQuoteId` carried on the lead's line items | `521` Quote ID Mismatch |
+| The fetched quote document's `quoteId` matches the request's `warrantyQuoteId` | `521` Quote ID Mismatch |
+| `warrantyQuoteItemId` resolves to an item inside the quote | `522` Quote Item Not Found |
+| `warrantyPrice` equals the resolved quote item's `policyPrice` (compared in cents) | `524` Warranty Price Mismatch |
+| `warrantyCoverageYears` equals the resolved quote item's `coverageYears` | `525` Warranty Coverage Years Mismatch |
+
+These gates run **before** any user account creation, contract write, or notification, so a rejected request leaves no partial state behind.
+
 ### Response
 
 On success, you will receive:

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -4287,8 +4287,34 @@
               }
             }
           },
-          "517": {
+          "516": {
             "description": "Contract Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "isError": {
+                      "type": "boolean",
+                      "description": "true"
+                    },
+                    "errorType": {
+                      "type": "integer",
+                      "description": "error type",
+                      "example": 516
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "error message",
+                      "example": "Contract not found"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "517": {
+            "description": "Line Items Update Not Allowed",
             "content": {
               "application/json": {
                 "schema": {
@@ -4306,7 +4332,7 @@
                     "message": {
                       "type": "string",
                       "description": "error message",
-                      "example": "Contract not found"
+                      "example": "Updates to line items are not permitted beyond 30 days from the date of sale."
                     }
                   }
                 }
@@ -4314,7 +4340,7 @@
             }
           },
           "518": {
-            "description": "Line Items Update Not Allowed",
+            "description": "Quote ID Mismatch",
             "content": {
               "application/json": {
                 "schema": {
@@ -4332,32 +4358,6 @@
                     "message": {
                       "type": "string",
                       "description": "error message",
-                      "example": "Updates to line items are not permitted beyond 30 days from the date of sale."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "521": {
-            "description": "Quote ID Mismatch",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "isError": {
-                      "type": "boolean",
-                      "description": "true"
-                    },
-                    "errorType": {
-                      "type": "integer",
-                      "description": "error type",
-                      "example": 521
-                    },
-                    "message": {
-                      "type": "string",
-                      "description": "error message",
                       "example": "Quote ID mismatch"
                     }
                   }
@@ -4365,7 +4365,7 @@
               }
             }
           },
-          "522": {
+          "519": {
             "description": "Quote Item Not Found",
             "content": {
               "application/json": {
@@ -4379,7 +4379,7 @@
                     "errorType": {
                       "type": "integer",
                       "description": "error type",
-                      "example": 522
+                      "example": 519
                     },
                     "message": {
                       "type": "string",
@@ -4391,7 +4391,7 @@
               }
             }
           },
-          "524": {
+          "520": {
             "description": "Warranty Price Mismatch",
             "content": {
               "application/json": {
@@ -4405,7 +4405,7 @@
                     "errorType": {
                       "type": "integer",
                       "description": "error type",
-                      "example": 524
+                      "example": 520
                     },
                     "message": {
                       "type": "string",
@@ -4417,7 +4417,7 @@
               }
             }
           },
-          "525": {
+          "521": {
             "description": "Warranty Coverage Years Mismatch",
             "content": {
               "application/json": {
@@ -4431,7 +4431,7 @@
                     "errorType": {
                       "type": "integer",
                       "description": "error type",
-                      "example": 525
+                      "example": 521
                     },
                     "message": {
                       "type": "string",

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -4287,32 +4287,6 @@
               }
             }
           },
-          "516": {
-            "description": "Contract Already Created",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "isError": {
-                      "type": "boolean",
-                      "description": "true"
-                    },
-                    "errorType": {
-                      "type": "integer",
-                      "description": "error type",
-                      "example": 516
-                    },
-                    "message": {
-                      "type": "string",
-                      "description": "error message",
-                      "example": "Contract already created"
-                    }
-                  }
-                }
-              }
-            }
-          },
           "517": {
             "description": "Contract Not Found",
             "content": {

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -4073,18 +4073,18 @@
                   },
                   "sbSalesLeadId": {
                     "type": "string",
-                    "description": "Unique identifier for the SureBright sales lead. Required — the contract's covered line items, purchase price, and warranty duration are derived from this lead.",
+                    "description": "Unique identifier for the SureBright sales lead. Required — the contract's covered line items, purchase price, and warranty duration are derived from this lead. The lead must belong to the requesting `storeId`; a lead that exists for another store is treated as not found (515).",
                     "example": "9f3e21c6-6bdb-4c7f-9b91-2a4f9a2c7d11"
                   },
                   "warrantyPrice": {
                     "type": "number",
                     "format": "float",
-                    "description": "Price of the warranty quote",
+                    "description": "Price of the warranty quote. Must equal the resolved quote item's `policyPrice` (compared in cents); otherwise the request is rejected with 524.",
                     "example": 40.0
                   },
                   "warrantyCoverageYears": {
                     "type": "integer",
-                    "description": "Duration of the warranty coverage in years",
+                    "description": "Duration of the warranty coverage in years. Must equal the resolved quote item's `coverageYears`; otherwise the request is rejected with 525.",
                     "example": 2
                   },
                   "customerDetails": {
@@ -4384,7 +4384,7 @@
                     "message": {
                       "type": "string",
                       "description": "error message",
-                      "example": "Quote ID mismatch with sales lead"
+                      "example": "Quote ID mismatch"
                     }
                   }
                 }
@@ -4411,6 +4411,58 @@
                       "type": "string",
                       "description": "error message",
                       "example": "Quote item not found"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "524": {
+            "description": "Warranty Price Mismatch",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "isError": {
+                      "type": "boolean",
+                      "description": "true"
+                    },
+                    "errorType": {
+                      "type": "integer",
+                      "description": "error type",
+                      "example": 524
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "error message",
+                      "example": "Warranty price does not match quote item"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "525": {
+            "description": "Warranty Coverage Years Mismatch",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "isError": {
+                      "type": "boolean",
+                      "description": "true"
+                    },
+                    "errorType": {
+                      "type": "integer",
+                      "description": "error type",
+                      "example": 525
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "error message",
+                      "example": "Warranty coverage years do not match quote item"
                     }
                   }
                 }

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -4023,8 +4023,8 @@
     },
     "/partner/api/v1/order/whole-system": {
       "post": {
-        "summary": "Create Contracts for Whole System Order",
-        "description": "This endpoint creates warranty contract for a whole system order. Submit the warranty quote details obtained from the List Quotes for Whole System Warranty endpoint along with the selected warranty plan and line item details. The API returns contract Id for the created warranty contract.",
+        "summary": "Create / Update Contracts for Whole System Warranty",
+        "description": "This endpoint creates or updates a warranty contract for a whole system order. Line items, total covered amount, and warranty duration are derived from the sales lead identified by `sbSalesLeadId`. Provide the warranty quote details and customer information; the API returns the contract ID. If a contract already exists for the given sales lead, the existing contract is updated instead of creating a new one.",
         "operationId": "createContractsForWholeSystemWarranty",
         "tags": [
           "orders"
@@ -4048,6 +4048,7 @@
                 "type": "object",
                 "required": [
                   "storeId",
+                  "sbSalesLeadId",
                   "warrantyQuoteId",
                   "warrantyQuoteItemId",
                   "warrantyPrice",
@@ -4072,7 +4073,7 @@
                   },
                   "sbSalesLeadId": {
                     "type": "string",
-                    "description": "A unique identifier for the SureBright sales lead",
+                    "description": "Unique identifier for the SureBright sales lead. Required — the contract's covered line items, purchase price, and warranty duration are derived from this lead.",
                     "example": "9f3e21c6-6bdb-4c7f-9b91-2a4f9a2c7d11"
                   },
                   "warrantyPrice": {
@@ -4092,12 +4093,7 @@
                     "required": [
                       "customerEmail",
                       "customerFirstName",
-                      "customerLastName",
-                      "customerAddress1",
-                      "customerCity",
-                      "customerState",
-                      "customerCountry",
-                      "customerZipCode"
+                      "customerLastName"
                     ],
                     "properties": {
                       "customerEmail": {
@@ -4158,51 +4154,6 @@
                         "example": "BILLING"
                       }
                     }
-                  },
-                  "lineItemList": {
-                    "type": "array",
-                    "description": "A list of line items representing the products in the order with coverage status",
-                    "items": {
-                      "type": "object",
-                      "required": [
-                        "title",
-                        "unitPrice",
-                        "quantity"
-                      ],
-                      "properties": {
-                        "title": {
-                          "type": "string",
-                          "description": "The title or name of the product",
-                          "example": "PMC Prophecy5 2-Way Floorstanding Speaker (Pair)"
-                        },
-                        "unitPrice": {
-                          "type": "number",
-                          "format": "float",
-                          "description": "The unit price of the product purchased",
-                          "example": 6500
-                        },
-                        "isCovered": {
-                          "type": "boolean",
-                          "description": "Indicates whether the line item is covered by the warranty",
-                          "example": true
-                        },
-                        "sbCategoryName": {
-                          "type": "string",
-                          "description": "The SureBright category name for the product",
-                          "example": "Speaker Floorstanding"
-                        },
-                        "quantity": {
-                          "type": "integer",
-                          "description": "The quantity of the product purchased",
-                          "example": 1
-                        },
-                        "description": {
-                          "type": "string",
-                          "description": "The description of the product",
-                          "example": "High-performance floorstanding speaker pair for immersive audio systems."
-                        }
-                      }
-                    }
                   }
                 }
               }
@@ -4226,32 +4177,6 @@
                       "type": "string",
                       "description": "The unique identifier for the warranty contract created",
                       "example": "54a3a238407f426e862a0a11cab11164"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "511": {
-            "description": "Insufficient Parameters",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "isError": {
-                      "type": "boolean",
-                      "description": "true"
-                    },
-                    "errorType": {
-                      "type": "integer",
-                      "description": "error type",
-                      "example": 511
-                    },
-                    "message": {
-                      "type": "string",
-                      "description": "error message",
-                      "example": "Insufficient Parameters"
                     }
                   }
                 }
@@ -4434,58 +4359,6 @@
                       "type": "string",
                       "description": "error message",
                       "example": "Updates to line items are not permitted beyond 30 days from the date of sale."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "519": {
-            "description": "Line Items Mismatch",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "isError": {
-                      "type": "boolean",
-                      "description": "true"
-                    },
-                    "errorType": {
-                      "type": "integer",
-                      "description": "error type",
-                      "example": 519
-                    },
-                    "message": {
-                      "type": "string",
-                      "description": "error message",
-                      "example": "Line items do not match sales lead"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "520": {
-            "description": "Covered Amount Mismatch",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "isError": {
-                      "type": "boolean",
-                      "description": "true"
-                    },
-                    "errorType": {
-                      "type": "integer",
-                      "description": "error type",
-                      "example": 520
-                    },
-                    "message": {
-                      "type": "string",
-                      "description": "error message",
-                      "example": "Covered amount does not match sales lead"
                     }
                   }
                 }


### PR DESCRIPTION
Line items, covered amount, and warranty duration are now derived from the sales lead. Drops lineItemList from the request and removes the related error codes (511, 519, 520). Reflects create-or-update behavior on the endpoint and loosens customer address requirements.