### PR TITLE
fix[Docs][API][Whole-System-Warranty] : Drop 520 Warranty-Price-Mismatch response

### DIFF
--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -4392,32 +4392,6 @@
             }
           },
           "520": {
-            "description": "Warranty Price Mismatch",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "isError": {
-                      "type": "boolean",
-                      "description": "true"
-                    },
-                    "errorType": {
-                      "type": "integer",
-                      "description": "error type",
-                      "example": 520
-                    },
-                    "message": {
-                      "type": "string",
-                      "description": "error message",
-                      "example": "Warranty price does not match quote item"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "521": {
             "description": "Warranty Coverage Years Mismatch",
             "content": {
               "application/json": {
@@ -4431,7 +4405,7 @@
                     "errorType": {
                       "type": "integer",
                       "description": "error type",
-                      "example": 521
+                      "example": 520
                     },
                     "message": {
                       "type": "string",


### PR DESCRIPTION
The createWholeSystemOrder flow no longer rejects requests where the warrantyPrice differs from the quote item's policyPrice; the request price is honored as-is. The 520 error response is removed and 521 Warranty Coverage Years Mismatch is renumbered to 520 to keep codes contiguous (513-520).