### PR TITLE
fix[Docs][API][Whole-System-Warranty] : Refresh stale property-level error code references

### DIFF
--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -4079,12 +4079,12 @@
                   "warrantyPrice": {
                     "type": "number",
                     "format": "float",
-                    "description": "Price of the warranty quote. Must equal the resolved quote item's `policyPrice` (compared in cents); otherwise the request is rejected with 524.",
+                    "description": "Price charged for the warranty quote. Honored as-is on the contract; the merchant absorbs any difference from the resolved quote item's `policyPrice` via `merchantMargin`.",
                     "example": 40.0
                   },
                   "warrantyCoverageYears": {
                     "type": "integer",
-                    "description": "Duration of the warranty coverage in years. Must equal the resolved quote item's `coverageYears`; otherwise the request is rejected with 525.",
+                    "description": "Duration of the warranty coverage in years. Must equal the resolved quote item's `coverageYears`; otherwise the request is rejected with 520.",
                     "example": 2
                   },
                   "customerDetails": {


### PR DESCRIPTION
The OpenAPI request body schema for /partner/api/v1/order/whole-system still cited the old error codes in field descriptions:
- warrantyPrice referenced 524; the strict price check was removed — the request price is now honored as-is and the merchant absorbs the diff via merchantMargin
- warrantyCoverageYears referenced 525; the contiguous-renumber landed this on 520